### PR TITLE
Fix incorrect PG: prefix in product_id docstrings (should be PR:)

### DIFF
--- a/src/mcp_server_spira/features/automation/tools/automatedtestruns.py
+++ b/src/mcp_server_spira/features/automation/tools/automatedtestruns.py
@@ -15,7 +15,7 @@ def _record_automated_test_run_impl(spira_client, product_id: int, test_name: st
 
     Args:
         spira_client: The Inflectra Spira API client instance
-        product_id: The numeric ID of the product. If the ID is PG:45, just use 45.
+        product_id: The numeric ID of the product. If the ID is PR:45, just use 45.
         test_name: The name of the test being run
         short_message: A short description (50 characters or less) of the result of the test execution
         long_message: The full description of the testing outcome, in plain text format
@@ -78,7 +78,7 @@ def register_tools(mcp) -> None:
         - Push the results of an automated software test into Spira
                     
         Args:
-            product_id: The numeric ID of the product. If the ID is PG:45, just use 45.
+            product_id: The numeric ID of the product. If the ID is PR:45, just use 45.
             test_name: The name of the test being run
             short_message: A short description (50 characters or less) of the result of the test execution
             long_message: The full description of the testing outcome, in plain text format

--- a/src/mcp_server_spira/features/automation/tools/builds.py
+++ b/src/mcp_server_spira/features/automation/tools/builds.py
@@ -15,7 +15,7 @@ def _create_build_url_impl(spira_client, product_id: int, release_id: int, build
 
     Args:
         spira_client: The Inflectra Spira API client instance
-        product_id: The numeric ID of the product. If the ID is PG:45, just use 45.
+        product_id: The numeric ID of the product. If the ID is PR:45, just use 45.
         release_id: The ID of the release/sprint/phase in Spira that the build is for, without the RL prefix (e.g. RL:12 would be 12)
         build_status_id: The status of the build (1=Failed, 2=Passed)
         name: The name of the build (usually containing the project name and the date/time of the build)
@@ -77,7 +77,7 @@ def register_tools(mcp) -> None:
         - Push the results of an automated software build into Spira
                     
         Args:
-            product_id: The numeric ID of the product. If the ID is PG:45, just use 45.
+            product_id: The numeric ID of the product. If the ID is PR:45, just use 45.
             release_id: The ID of the release/sprint/phase in Spira that the build is for, without the RL prefix (e.g. RL:12 would be 12)
             build_status_id: The status of the build (1=Failed, 2=Passed)
             name: The name of the build (usually containing the project name and the date/time of the build)

--- a/src/mcp_server_spira/features/productartifacts/tools/automationhosts.py
+++ b/src/mcp_server_spira/features/productartifacts/tools/automationhosts.py
@@ -13,7 +13,7 @@ def _get_automation_hosts_impl(spira_client, product_id: int) -> str:
 
     Args:
         spira_client: The Inflectra Spira API client instance
-        product_id: The numeric ID of the product. If the ID is PG:45, just use 45. 
+        product_id: The numeric ID of the product. If the ID is PR:45, just use 45. 
                 
     Returns:
         Formatted string containing the list of automation hosts
@@ -56,7 +56,7 @@ def register_tools(mcp) -> None:
         - Access the full description and selected fields of automation hosts
 
         Args:
-            product_id: The numeric ID of the product. If the ID is PG:45, just use 45. 
+            product_id: The numeric ID of the product. If the ID is PR:45, just use 45. 
         
         Returns:
             Formatted string containing comprehensive information for the

--- a/src/mcp_server_spira/features/productartifacts/tools/testcases.py
+++ b/src/mcp_server_spira/features/productartifacts/tools/testcases.py
@@ -91,7 +91,7 @@ def register_tools(mcp) -> None:
         - Access the full description and selected fields of test cases
 
         Args:
-            product_id: The numeric ID of the product. If the ID is PG:45, just use 45. 
+            product_id: The numeric ID of the product. If the ID is PR:45, just use 45. 
         
         Returns:
             Formatted string containing comprehensive information for the

--- a/src/mcp_server_spira/features/productartifacts/tools/testsets.py
+++ b/src/mcp_server_spira/features/productartifacts/tools/testsets.py
@@ -91,7 +91,7 @@ def register_tools(mcp) -> None:
         - Access the full description and selected fields of test sets
 
         Args:
-            product_id: The numeric ID of the product. If the ID is PG:45, just use 45. 
+            product_id: The numeric ID of the product. If the ID is PR:45, just use 45. 
         
         Returns:
             Formatted string containing comprehensive information for the


### PR DESCRIPTION
Fixes #8.

## Problem

Five MCP tools that operate on products had an example prefix of `PG:45` (program prefix) in their `product_id` argument docstring. The `PR:` prefix is what's used for products elsewhere in the codebase.

## Affected tools

- `create_build`
- `record_automated_test_run`
- `get_automation_hosts`
- `get_test_cases`
- `get_test_sets`

## Change

Single-character substitution in 8 lines across 5 files (`PG:45` → `PR:45`). No logic changes.

## Verification

- The same file (`products.py`) demonstrates the intentional `PR` (product) vs `PG` (program) distinction at [L16](https://github.com/Inflectra/mcp-server-spira/blob/6f043c1a11f695ab1ccc2eaa34cef459266f483b/src/mcp_server_spira/features/workspaces/tools/products.py#L16) and [L73](https://github.com/Inflectra/mcp-server-spira/blob/6f043c1a11f695ab1ccc2eaa34cef459266f483b/src/mcp_server_spira/features/workspaces/tools/products.py#L73).
- Formatting helpers in `formatting.py` consistently render `[PR:N]` for products ([L81](https://github.com/Inflectra/mcp-server-spira/blob/6f043c1a11f695ab1ccc2eaa34cef459266f483b/src/mcp_server_spira/features/formatting.py#L81)) and `[PG:N]` for programs ([L101](https://github.com/Inflectra/mcp-server-spira/blob/6f043c1a11f695ab1ccc2eaa34cef459266f483b/src/mcp_server_spira/features/formatting.py#L101)).
- All five affected tools use product-scoped API URLs (`projects/{product_id}/...`).

## Base

Branched from `6f043c1a11f695ab1ccc2eaa34cef459266f483b` (current `main`).

See #8 for full details and per-line permalinks of each occurrence.
