### PR TITLE
docs: fix PG/PR prefix typo in automatedtestruns.py

### DIFF
--- a/src/mcp_server_spira/features/automation/tools/automatedtestruns.py
+++ b/src/mcp_server_spira/features/automation/tools/automatedtestruns.py
@@ -32,7 +32,7 @@ async def _record_automated_test_run_impl(
 
     Args:
         spira_client: The Inflectra Spira API client instance
-        product_id: The numeric ID of the product. If the ID is PG:45, just use 45.
+        product_id: The numeric ID of the product. If the ID is PR:45, just use 45.
         test_name: The name of the test being run
         short_message: A short description (50 characters or less) of the result of the test execution
         long_message: The full description of the testing outcome, in plain text format


### PR DESCRIPTION
Fixes #8

Follow-up to #9, against the rewrite in #18 (`ee93b0f`).

#9 flagged the `PG:` / `PR:` prefix typo in 5 tools. The rewrite resolved 4 of them (3 by consolidating into `product_search_artifacts`, 1 by fixing `builds.py:32` directly). One remains in `automatedtestruns.py:35`:

```diff
-        product_id: The numeric ID of the product. If the ID is PG:45, just use 45.
+        product_id: The numeric ID of the product. If the ID is PR:45, just use 45.
```

`PG:` is the prefix for Programs, `PR:` for Products.
